### PR TITLE
Add two more test cases

### DIFF
--- a/caa_test.go
+++ b/caa_test.go
@@ -39,6 +39,8 @@ type testcaseInfo struct {
 var testcases = []testcaseInfo{
     {"empty.basic.caatestsuite.com.", ";"},
     {"deny.basic.caatestsuite.com.", "caatestsuite.com"},
+    {"sub1.deny.basic.caatestsuite.com.", "caatestsuite.com"},
+    {"sub2.sub1.deny.basic.caatestsuite.com.", "caatestsuite.com"},
     {"*.deny.basic.caatestsuite.com.", "caatestsuite.com"},
     {"cname-deny.basic.caatestsuite.com.", "caatestsuite.com"},
     {"cname-cname-deny.basic.caatestsuite.com.", "caatestsuite.com"},


### PR DESCRIPTION
Subdomains of a domain that has a CAA record. Tests work without
modification to the code.